### PR TITLE
Frontend: Detect links in text chat

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -27,6 +27,7 @@
         "@types/simple-peer": "^9.11.5",
         "@types/three": "^0.163.0",
         "http-proxy-middleware": "^2.0.6",
+        "linkify-react": "^4.1.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hot-toast": "^2.4.1",
@@ -12082,6 +12083,23 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+    },
+    "node_modules/linkify-react": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/linkify-react/-/linkify-react-4.1.3.tgz",
+      "integrity": "sha512-rhI3zM/fxn5BfRPHfi4r9N7zgac4vOIxub1wHIWXLA5ENTMs+BGaIaFO1D1PhmxgwhIKmJz3H7uCP0Dg5JwSlA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "linkifyjs": "^4.0.0",
+        "react": ">= 15.0.0"
+      }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.1.3.tgz",
+      "integrity": "sha512-auMesunaJ8yfkHvK4gfg1K0SaKX/6Wn9g2Aac/NwX+l5VdmFZzo/hdPGxEOETj+ryRa4/fiOPjeeKURSAJx1sg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/loader-runner": {
       "version": "4.3.0",
@@ -26537,6 +26555,18 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+    },
+    "linkify-react": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/linkify-react/-/linkify-react-4.1.3.tgz",
+      "integrity": "sha512-rhI3zM/fxn5BfRPHfi4r9N7zgac4vOIxub1wHIWXLA5ENTMs+BGaIaFO1D1PhmxgwhIKmJz3H7uCP0Dg5JwSlA==",
+      "requires": {}
+    },
+    "linkifyjs": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.1.3.tgz",
+      "integrity": "sha512-auMesunaJ8yfkHvK4gfg1K0SaKX/6Wn9g2Aac/NwX+l5VdmFZzo/hdPGxEOETj+ryRa4/fiOPjeeKURSAJx1sg==",
+      "peer": true
     },
     "loader-runner": {
       "version": "4.3.0",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -22,6 +22,7 @@
     "@types/simple-peer": "^9.11.5",
     "@types/three": "^0.163.0",
     "http-proxy-middleware": "^2.0.6",
+    "linkify-react": "^4.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.4.1",

--- a/Frontend/src/pages/Room/components/VideoChat/ChatMessage.tsx
+++ b/Frontend/src/pages/Room/components/VideoChat/ChatMessage.tsx
@@ -1,4 +1,5 @@
 import { Fragment, FunctionComponent } from 'react';
+import Linkify from 'linkify-react';
 import { Typography } from '../../../../components/Typography/Typography';
 import { useThemeClassName } from '../../../../hooks/useThemeClassName';
 import { Theme } from '../../../../context/ThemeContext';
@@ -57,7 +58,9 @@ export const ChatMessage: FunctionComponent<ChatMessageProps> = ({
             </div>
           )}
           <Gap sizeRem={0.25} />
-          <Typography size='s'>{message}</Typography>
+            <Typography size='s'>
+              <Linkify options={{ target: '_blank', rel: 'noopener noreferrer' }}>{message}</Linkify>
+            </Typography>
           <div className='text-right'>
             <Typography size='xs' secondary>{formatTime(new Date(createdAt))}</Typography>
           </div>


### PR DESCRIPTION
![1](https://github.com/user-attachments/assets/fc551069-ea4b-4f00-9498-a67bc80036b3)

Выбирал из 3х библиотек:
anchorme (https://www.npmjs.com/package/anchorme), крайнее обновление 7 месяцев назад, ~70k ежедневных скачиваний
linkify (https://www.npmjs.com/package/linkifyjs), крайнее обновление год назад, ~1 365k ежедневных скачиваний
autolinker (https://www.npmjs.com/package/autolinker), крайнее обновление 2 года назад, ~925k ежедневных скачиваний

Anchorme откинул т.к. она ощутимо проигрывает в популярности + нет компонента на реакт.
Linkify приглянулась более чем autolinker, за счет наличия подробной документации и особенно информации о безопасности реакт компонента от xss (https://linkify.js.org/docs/xss.html).

Компонент для реакт работает практически из коробки, дополнительно потребовалось добавить к ссылке только { target: '_blank', rel: 'noopener noreferrer' }, чобы открывать ссылку на новой вкладке и чтобы новая вкладка не имела доступа к исходной странице через свойство window.opener