### PR TITLE
Implement question analytics feature in QuestionController

### DIFF
--- a/Backend/Interview.Backend/Questions/QuestionController.cs
+++ b/Backend/Interview.Backend/Questions/QuestionController.cs
@@ -137,4 +137,19 @@ public class QuestionController(IQuestionService questionService) : ControllerBa
     {
         return questionService.DeletePermanentlyAsync(id, HttpContext.RequestAborted);
     }
+
+    /// <summary>
+    /// Get analytics for a question.
+    /// </summary>
+    /// <param name="id">Question ID.</param>
+    /// <returns>Question analytics data.</returns>
+    [Authorize]
+    [HttpGet("{id:guid}/analytics")]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(QuestionAnalytics), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(MessageResponse), StatusCodes.Status404NotFound)]
+    public Task<QuestionAnalytics> GetAnalyticsAsync(Guid id)
+    {
+        return questionService.GetAnalyticsAsync(id, HttpContext.RequestAborted);
+    }
 }

--- a/Backend/Interview.Domain/Permissions/EVPermission.cs
+++ b/Backend/Interview.Domain/Permissions/EVPermission.cs
@@ -32,6 +32,9 @@ public enum EVPermission
     [Description("Unarchiving the question")]
     QuestionUnarchive,
 
+    [Description("Getting analytics for a question")]
+    QuestionGetAnalytics,
+
     [Description("Getting the reactions page")]
     ReactionFindPage,
 

--- a/Backend/Interview.Domain/Permissions/SEPermission.cs
+++ b/Backend/Interview.Domain/Permissions/SEPermission.cs
@@ -49,6 +49,10 @@ public class SEPermission(Guid id, EVPermission value) : SmartEnum<SEPermission>
         Guid.Parse("32e18595-1c0a-4dd5-bad7-2cbfbccbcb2a"),
         EVPermission.QuestionUnarchive);
 
+    public static readonly SEPermission QuestionGetAnalytics = new(
+        Guid.Parse("f8d2e595-1c0a-4dd5-bad7-2cbfbccbcb2b"),
+        EVPermission.QuestionGetAnalytics);
+
     public static readonly SEPermission ReactionFindPage = new(
         Guid.Parse("004cca49-9857-4973-9bda-79b57f60279b"),
         EVPermission.ReactionFindPage);

--- a/Backend/Interview.Domain/Questions/Permissions/QuestionServicePermissionAccessor.cs
+++ b/Backend/Interview.Domain/Questions/Permissions/QuestionServicePermissionAccessor.cs
@@ -103,4 +103,10 @@ public class QuestionServicePermissionAccessor(IQuestionService questionService,
         await securityService.EnsurePermissionAsync(SEPermission.QuestionUnarchive, cancellationToken);
         return await questionService.UnarchiveAsync(id, cancellationToken);
     }
+
+    public async Task<QuestionAnalytics> GetAnalyticsAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        await securityService.EnsurePermissionAsync(SEPermission.QuestionGetAnalytics, cancellationToken);
+        return await questionService.GetAnalyticsAsync(id, cancellationToken);
+    }
 }

--- a/Backend/Interview.Domain/Questions/QuestionAnalytics.cs
+++ b/Backend/Interview.Domain/Questions/QuestionAnalytics.cs
@@ -1,0 +1,27 @@
+using Interview.Domain.Rooms.RoomParticipants;
+
+namespace Interview.Domain.Questions;
+
+public class QuestionAnalytics
+{
+    public required double? AverageMark { get; set; }
+    
+    public required bool Completed { get; set; }
+    
+    public required List<AnalyticsUserEvaluation> Evaluations { get; set; }
+
+    public class AnalyticsUserEvaluation
+    {
+        public required Guid UserId { get; set; }
+        
+        public required string Nickname { get; set; } = string.Empty;
+        
+        public required string? Avatar { get; set; }
+        
+        public required EVRoomParticipantType ParticipantType { get; set; }
+        
+        public required int? Mark { get; set; }
+        
+        public required string? Review { get; set; }
+    }
+} 

--- a/Backend/Interview.Domain/Questions/Services/IQuestionService.cs
+++ b/Backend/Interview.Domain/Questions/Services/IQuestionService.cs
@@ -37,4 +37,6 @@ public interface IQuestionService : IService
     Task ArchiveQuestionTreeAsync(Guid id, CancellationToken cancellationToken = default);
 
     Task UnarchiveQuestionTreeAsync(Guid id, CancellationToken cancellationToken = default);
+
+    Task<QuestionAnalytics> GetAnalyticsAsync(Guid id, CancellationToken cancellationToken = default);
 }

--- a/Backend/Interview.Domain/Questions/Services/QuestionAnalyticService.cs
+++ b/Backend/Interview.Domain/Questions/Services/QuestionAnalyticService.cs
@@ -1,0 +1,73 @@
+using Interview.Domain.Database;
+using Interview.Domain.Rooms.RoomParticipants;
+using Interview.Domain.Rooms.RoomQuestionEvaluations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Interview.Domain.Questions.Services;
+
+public sealed class QuestionAnalyticService(AppDbContext db) : ISelfScopeService
+{
+    public async Task<QuestionAnalytics> GetAnalyticsAsync(Guid questionId, CancellationToken cancellationToken = default)
+    {
+        var question = await db.Questions
+            .AsNoTracking()
+            .Include(q => q.RoomQuestions)
+                .ThenInclude(rq => rq.Evaluations)
+                    .ThenInclude(e => e.CreatedBy)
+            .Include(q => q.RoomQuestions)
+                .ThenInclude(rq => rq.Room)
+                    .ThenInclude(r => r!.Participants)
+            .FirstOrDefaultAsync(q => q.Id == questionId, cancellationToken);
+
+        if (question == null)
+        {
+            throw NotFoundException.Create<Question>(questionId);
+        }
+
+        var evaluations = new List<QuestionAnalytics.AnalyticsUserEvaluation>();
+        var allEvaluationsSubmitted = true;
+
+        foreach (var roomQuestion in question.RoomQuestions)
+        {
+            var participants = roomQuestion.Room!.Participants
+                .ToDictionary(p => p.UserId, p => p.Type);
+
+            foreach (var evaluation in roomQuestion.Evaluations)
+            {
+                if (evaluation.State == SERoomQuestionEvaluationState.Draft)
+                {
+                    allEvaluationsSubmitted = false;
+                    continue;
+                }
+
+                if (evaluation.State == SERoomQuestionEvaluationState.Submitted)
+                {
+                    evaluations.Add(new QuestionAnalytics.AnalyticsUserEvaluation
+                    {
+                        UserId = evaluation.CreatedBy!.Id,
+                        Nickname = evaluation.CreatedBy.Nickname,
+                        Avatar = evaluation.CreatedBy.Avatar,
+                        ParticipantType = participants[evaluation.CreatedBy.Id].EnumValue,
+                        Mark = evaluation.Mark,
+                        Review = evaluation.Review
+                    });
+                }
+            }
+        }
+
+        var analytics = new QuestionAnalytics
+        {
+            Completed = allEvaluationsSubmitted,
+            Evaluations = evaluations,
+            AverageMark = allEvaluationsSubmitted && evaluations.Any() 
+                ? evaluations
+                    .Where(e => e.Mark is not null && e.Mark.Value > 0)
+                    .Select(e => e.Mark!.Value)
+                    .DefaultIfEmpty(0)
+                    .Average()
+                : null
+        };
+
+        return analytics;
+    }
+} 

--- a/Backend/Interview.Domain/Users/Roles/RoleName.cs
+++ b/Backend/Interview.Domain/Users/Roles/RoleName.cs
@@ -59,6 +59,7 @@ public sealed class RoleName : SmartEnum<RoleName>
             SEPermission.GetQuestionTreeById,
             SEPermission.RoadmapGetById,
             SEPermission.RoadmapFindPage,
+            SEPermission.QuestionGetAnalytics,
         });
 
     public static readonly RoleName Admin = new(


### PR DESCRIPTION
Implement question analytics feature in QuestionController and related services

- Added GetAnalyticsAsync method in QuestionController to retrieve analytics for a specific question.
- Introduced QuestionAnalytics class to encapsulate analytics data, including average marks and user evaluations.
- Updated IQuestionService and QuestionService to support analytics retrieval.
- Added necessary permissions for accessing question analytics.
- Created QuestionAnalyticService to handle the logic for fetching analytics from the database.