### PR TITLE
Add closed questions analytics feature

### DIFF
--- a/Backend/Interview.Backend/RoomQuestions/RoomQuestionController.cs
+++ b/Backend/Interview.Backend/RoomQuestions/RoomQuestionController.cs
@@ -54,4 +54,19 @@ public class RoomQuestionController(IRoomQuestionService roomQuestionService) : 
     {
         return roomQuestionService.GetAnswerDetailsAsync(request, HttpContext.RequestAborted);
     }
+
+    /// <summary>
+    /// Get analytics for closed questions.
+    /// </summary>
+    /// <param name="roomId">Room ID.</param>
+    /// <returns>Analytics for closed questions.</returns>
+    [Authorize]
+    [HttpGet("closed-analytics/{roomId:guid}")]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(RoomQuestionClosedAnalytics), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(MessageResponse), StatusCodes.Status404NotFound)]
+    public Task<RoomQuestionClosedAnalytics> GetClosedQuestionsAnalyticsAsync(Guid roomId)
+    {
+        return roomQuestionService.GetClosedQuestionsAnalyticsAsync(roomId, HttpContext.RequestAborted);
+    }
 }

--- a/Backend/Interview.Domain/Permissions/EVPermission.cs
+++ b/Backend/Interview.Domain/Permissions/EVPermission.cs
@@ -241,5 +241,8 @@ public enum EVPermission
 
     [Description("Find archived roadmap page")]
     RoadmapFindArchivedPage,
+
+    [Description("Getting closed questions analytics")]
+    GetRoomQuestionClosedAnalytics,
 #pragma warning restore SA1602
 }

--- a/Backend/Interview.Domain/Permissions/SEPermission.cs
+++ b/Backend/Interview.Domain/Permissions/SEPermission.cs
@@ -351,6 +351,10 @@ public class SEPermission(Guid id, EVPermission value) : SmartEnum<SEPermission>
         Guid.Parse("D281118B-2806-4563-9381-ED7EA47D6578"),
         EVPermission.RoadmapFindArchivedPage);
 
+    public static readonly SEPermission GetRoomQuestionClosedAnalytics = new(
+        Guid.Parse("7D8F5E3A-B2C1-4E9D-9F6A-1234567890AB"),
+        EVPermission.GetRoomQuestionClosedAnalytics);
+
     public Guid Id { get; } = id;
 
     public string Description { get; } = _descriptionMap[value];

--- a/Backend/Interview.Domain/Rooms/RoomParticipants/SERoomParticipantType.cs
+++ b/Backend/Interview.Domain/Rooms/RoomParticipants/SERoomParticipantType.cs
@@ -51,6 +51,7 @@ public sealed class SERoomParticipantType : SmartEnum<SERoomParticipantType>
         SEPermission.RoomReviewCompletion,
         SEPermission.RoomReviewUpsert,
         SEPermission.GetRoomQuestionAnswerDetails,
+        SEPermission.GetRoomQuestionClosedAnalytics,
     });
 
     public static readonly SERoomParticipantType Examinee = new("Examinee", EVRoomParticipantType.Examinee, new HashSet<SEPermission>

--- a/Backend/Interview.Domain/Rooms/RoomQuestions/Permissions/RoomQuestionServicePermissionAccessor.cs
+++ b/Backend/Interview.Domain/Rooms/RoomQuestions/Permissions/RoomQuestionServicePermissionAccessor.cs
@@ -46,4 +46,10 @@ public class RoomQuestionServicePermissionAccessor(
         await securityService.EnsureRoomPermissionAsync(request.RoomId, SEPermission.RoomQuestionFindGuids, cancellationToken);
         return await roomQuestionService.FindQuestionsAsync(request, cancellationToken);
     }
+
+    public async Task<RoomQuestionClosedAnalytics> GetClosedQuestionsAnalyticsAsync(Guid roomId, CancellationToken cancellationToken = default)
+    {
+        await securityService.EnsureRoomPermissionAsync(roomId, SEPermission.GetRoomQuestionClosedAnalytics, cancellationToken);
+        return await roomQuestionService.GetClosedQuestionsAnalyticsAsync(roomId, cancellationToken);
+    }
 }

--- a/Backend/Interview.Domain/Rooms/RoomQuestions/Records/Response/RoomQuestionClosedAnalytics.cs
+++ b/Backend/Interview.Domain/Rooms/RoomQuestions/Records/Response/RoomQuestionClosedAnalytics.cs
@@ -1,0 +1,40 @@
+using Interview.Domain.Rooms.RoomQuestionEvaluations;
+
+namespace Interview.Domain.Rooms.RoomQuestions.Records.Response;
+
+public class RoomQuestionClosedAnalytics
+{
+    public required List<ClosedQuestionAnalytics> Questions { get; set; }
+    public required double? OverallAverageMark { get; set; }
+    public required int TotalClosedQuestions { get; set; }
+    public required int TotalEvaluations { get; set; }
+    public required DateTime LastClosedQuestionDate { get; set; }
+
+    public class ClosedQuestionAnalytics
+    {
+        public required Guid QuestionId { get; set; }
+        public required string QuestionValue { get; set; }
+        public required DateTime ClosedDate { get; set; }
+        public required double? AverageMark { get; set; }
+        public required int TotalEvaluations { get; set; }
+        public required List<EvaluationDistribution> MarkDistribution { get; set; }
+        public required List<EvaluatorSummary> TopEvaluators { get; set; }
+    }
+
+    public class EvaluationDistribution
+    {
+        public required int Mark { get; set; }
+        public required int Count { get; set; }
+        public required double Percentage { get; set; }
+    }
+
+    public class EvaluatorSummary
+    {
+        public required Guid UserId { get; set; }
+        public required string Nickname { get; set; }
+        public required string? Avatar { get; set; }
+        public required EVRoomParticipantType ParticipantType { get; set; }
+        public required double AverageMark { get; set; }
+        public required int TotalEvaluations { get; set; }
+    }
+} 

--- a/Backend/Interview.Domain/Rooms/RoomQuestions/Services/IRoomQuestionService.cs
+++ b/Backend/Interview.Domain/Rooms/RoomQuestions/Services/IRoomQuestionService.cs
@@ -21,4 +21,6 @@ public interface IRoomQuestionService : IService
 
     Task<List<RoomQuestionResponse>> FindQuestionsAsync(
         RoomQuestionsRequest request, CancellationToken cancellationToken = default);
+
+    Task<RoomQuestionClosedAnalytics> GetClosedQuestionsAnalyticsAsync(Guid roomId, CancellationToken cancellationToken = default);
 }

--- a/Backend/Interview.Migrations.Postgres/Migrations/20240321000000_add_room_question_closed_analytics_permission.cs
+++ b/Backend/Interview.Migrations.Postgres/Migrations/20240321000000_add_room_question_closed_analytics_permission.cs
@@ -1,0 +1,47 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Interview.Migrations.Postgres.Migrations;
+
+/// <inheritdoc />
+public partial class add_room_question_closed_analytics_permission : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.InsertData(
+            table: "Permissions",
+            columns: new[] { "Id", "CreateDate", "CreatedById", "Type", "UpdateDate" },
+            values: new object[] { new Guid("7D8F5E3A-B2C1-4E9D-9F6A-1234567890AB"), new DateTime(2024, 3, 21, 0, 0, 0, 0, DateTimeKind.Unspecified), null, "GetRoomQuestionClosedAnalytics", new DateTime(2024, 3, 21, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+        migrationBuilder.InsertData(
+            table: "AvailableRoomPermission",
+            columns: new[] { "Id", "CreateDate", "CreatedById", "PermissionId", "RoomParticipantId", "UpdateDate" },
+            values: new object[] { new Guid("8A9F6B4C-D3E2-4F1A-B5C7-1234567890AB"), new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), null, new Guid("7D8F5E3A-B2C1-4E9D-9F6A-1234567890AB"), null, new DateTime(2024, 3, 21, 15, 0, 0, 0, DateTimeKind.Utc) });
+
+        migrationBuilder.Sql(@"
+            INSERT INTO ""RoomParticipantPermission"" (""FK_PERMISSION_ID"", ""FK_PARTICIPANT_ID"")
+            SELECT permissions.""Id"", RP.""Id""
+            FROM ""RoomParticipants"" RP,
+            (SELECT permission.""Id"", permission.""Type""
+            FROM ""Permissions"" permission
+                WHERE ""Type"" = 'GetRoomQuestionClosedAnalytics') permissions
+                WHERE RP.""Type"" = 'Expert'");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DeleteData(
+            table: "AvailableRoomPermission",
+            keyColumn: "Id",
+            keyValue: new Guid("8A9F6B4C-D3E2-4F1A-B5C7-1234567890AB"));
+
+        migrationBuilder.DeleteData(
+            table: "Permissions",
+            keyColumn: "Id",
+            keyValue: new Guid("7D8F5E3A-B2C1-4E9D-9F6A-1234567890AB"));
+    }
+} 

--- a/Backend/Interview.Migrations.Sqlite/Migrations/20240321000000_add_room_question_closed_analytics_permission.cs
+++ b/Backend/Interview.Migrations.Sqlite/Migrations/20240321000000_add_room_question_closed_analytics_permission.cs
@@ -1,0 +1,47 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Interview.Migrations.Sqlite.Migrations;
+
+/// <inheritdoc />
+public partial class add_room_question_closed_analytics_permission : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.InsertData(
+            table: "Permissions",
+            columns: new[] { "Id", "CreateDate", "CreatedById", "Type", "UpdateDate" },
+            values: new object[] { new Guid("7D8F5E3A-B2C1-4E9D-9F6A-1234567890AB"), new DateTime(2024, 3, 21, 0, 0, 0, 0, DateTimeKind.Unspecified), null, "GetRoomQuestionClosedAnalytics", new DateTime(2024, 3, 21, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+        migrationBuilder.InsertData(
+            table: "AvailableRoomPermission",
+            columns: new[] { "Id", "CreateDate", "CreatedById", "PermissionId", "RoomParticipantId", "UpdateDate" },
+            values: new object[] { new Guid("8A9F6B4C-D3E2-4F1A-B5C7-1234567890AB"), new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), null, new Guid("7D8F5E3A-B2C1-4E9D-9F6A-1234567890AB"), null, new DateTime(2024, 3, 21, 15, 0, 0, 0, DateTimeKind.Utc) });
+
+        migrationBuilder.Sql(@"
+            INSERT INTO ""RoomParticipantPermission"" (""FK_PERMISSION_ID"", ""FK_PARTICIPANT_ID"")
+            SELECT permissions.""Id"", RP.""Id""
+            FROM ""RoomParticipants"" RP,
+            (SELECT permission.""Id"", permission.""Type""
+            FROM ""Permissions"" permission
+                WHERE ""Type"" = 'GetRoomQuestionClosedAnalytics') permissions
+                WHERE RP.""Type"" = 'Expert'");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DeleteData(
+            table: "AvailableRoomPermission",
+            keyColumn: "Id",
+            keyValue: new Guid("8A9F6B4C-D3E2-4F1A-B5C7-1234567890AB"));
+
+        migrationBuilder.DeleteData(
+            table: "Permissions",
+            keyColumn: "Id",
+            keyValue: new Guid("7D8F5E3A-B2C1-4E9D-9F6A-1234567890AB"));
+    }
+} 


### PR DESCRIPTION
- Implemented GetClosedQuestionsAnalyticsAsync method in RoomQuestionService to retrieve analytics for closed questions.
- Added RoomQuestionClosedAnalytics model to structure the analytics data.
- Updated RoomQuestionController to expose a new endpoint for closed questions analytics.
- Introduced necessary permissions for accessing closed questions analytics.
- Created database migrations to add the new permission and associated data.

This feature enhances the ability to analyze closed questions within rooms, providing insights into evaluations and participant performance.